### PR TITLE
feat: replace `x11-clipboard` with `caracal`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,32 +36,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update && \
-          sudo apt-get install -y \
-            libx11-xcb-dev \
-            libxcb-xfixes0-dev \
-            libxcb-render0-dev \
-            libxcb-shape0-dev
-
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cache Cargo
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{runner.os}}-cargo-registry-${{hashFiles('**/Cargo.lock')}}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{runner.os}}-cargo-index-${{hashFiles('**/Cargo.lock')}}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{runner.os}}-cargo-build-target-${{hashFiles('**/Cargo.lock')}}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Main Toolchain
         uses: actions-rs/toolchain@v1
@@ -69,15 +51,10 @@ jobs:
           toolchain: stable
           target: ${{matrix.target}}
           profile: minimal
-          components: clippy, rustfmt
+          components: clippy
           override: true
 
-      - name: Version
-        run: |
-          rustup --version
-          cargo --version
-
-      - name: Install Rustfmt Toolchain
+      - name: Install Rustfmt (Nightly)
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -85,16 +62,21 @@ jobs:
           profile: minimal
           components: rustfmt
 
-      - name: Format
-        run: cargo +nightly fmt --all -- --check
-
-      - name: Clippy
+      - name: Show Toolchain Version
         run: |
-          cargo clippy --all
+          rustup --version
+          cargo --version
+          cargo +nightly fmt --version
           cargo clippy --version
 
+      - name: Check Format
+        run: cargo +nightly fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --all
+
       - name: Build
-        run: cargo build --all --verbose
+        run: cargo build --features=all --verbose
 
       - name: Test
         run: cargo test --all --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,9 +120,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "beef"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474a626a67200bd107d44179bb3d4fc61891172d11696609264589be6a0e6a43"
+checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
 
 [[package]]
 name = "bincode"
@@ -176,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
 
 [[package]]
+name = "bumpalo"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+
+[[package]]
 name = "byteorder"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,10 +200,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
+name = "caracal"
+version = "0.1.0"
+source = "git+https://github.com/xrelkd/caracal.git?tag=v0.1.0#3de6c0359cc81168498bc84f97ef70e1eee72fba"
+dependencies = [
+ "mime",
+ "serde",
+ "snafu",
+ "tracing",
+ "x11rb",
+]
+
+[[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 dependencies = [
  "jobserver",
 ]
@@ -226,7 +250,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.43",
  "winapi 0.3.9",
 ]
 
@@ -262,10 +286,12 @@ version = "0.5.0"
 dependencies = [
  "app_dirs",
  "bincode",
+ "caracal",
  "daemonize",
  "futures",
  "http",
  "libc",
+ "mime",
  "prost",
  "rocksdb",
  "serde",
@@ -282,7 +308,6 @@ dependencies = [
  "tracing-futures",
  "tracing-journald",
  "tracing-subscriber",
- "x11-clipboard",
 ]
 
 [[package]]
@@ -299,16 +324,16 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crossbeam"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
 dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-channel 0.4.4",
- "crossbeam-deque 0.7.3",
- "crossbeam-epoch 0.8.2",
+ "cfg-if 1.0.0",
+ "crossbeam-channel 0.5.0",
+ "crossbeam-deque",
+ "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils 0.8.2",
 ]
 
 [[package]]
@@ -328,18 +353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.1",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
-dependencies = [
- "crossbeam-epoch 0.8.2",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "crossbeam-utils 0.8.2",
 ]
 
 [[package]]
@@ -349,48 +363,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.1",
- "crossbeam-utils 0.8.1",
+ "crossbeam-epoch",
+ "crossbeam-utils 0.8.2",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "lazy_static",
- "maybe-uninit",
- "memoffset 0.5.6",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.2",
  "lazy_static",
- "memoffset 0.6.1",
+ "loom",
+ "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
 dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.2",
 ]
 
 [[package]]
@@ -406,13 +404,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -431,8 +430,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.10.2",
+ "darling_macro 0.10.2",
+]
+
+[[package]]
+name = "darling"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bfca34df8d0d73d61f26ce03a8be6da606d6c419a10c099009a879c165d2a71"
+dependencies = [
+ "darling_core 0.12.1",
+ "darling_macro 0.12.1",
 ]
 
 [[package]]
@@ -450,12 +459,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893119a69874649edb8ee1b912a7f367f251c5c862c45d3eed7abad2535e766b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
- "darling_core",
+ "darling_core 0.10.2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86184131efd474ebc1264537cfc8bbe9710f73846d02cc0305370410b848ef0f"
+dependencies = [
+ "darling_core 0.12.1",
  "quote",
  "syn",
 ]
@@ -476,7 +510,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
- "darling",
+ "darling 0.10.2",
  "derive_builder_core",
  "proc-macro2",
  "quote",
@@ -489,7 +523,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
- "darling",
+ "darling 0.10.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -517,6 +551,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,12 +570,12 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log",
  "regex",
  "termcolor",
@@ -543,12 +583,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -568,9 +608,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -583,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -593,15 +633,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -610,15 +650,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -628,24 +668,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -668,6 +705,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -785,6 +845,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,7 +866,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
+ "pin-project",
  "socket2",
  "tokio",
  "tower-service",
@@ -862,9 +928,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.85"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "libloading"
@@ -898,6 +964,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+]
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,15 +997,6 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
@@ -937,10 +1005,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.7.7"
+name = "mime"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mio"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
  "log",
@@ -976,6 +1050,18 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]
@@ -1038,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "4ad167a2f54e832b82dbe003a046280dceffe5227b5f79e08e363a29638cfddd"
 
 [[package]]
 name = "peeking_take_while"
@@ -1066,31 +1152,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
-dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 1.0.5",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -1226,9 +1292,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1257,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
 ]
@@ -1280,7 +1346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
 dependencies = [
  "autocfg",
- "crossbeam-deque 0.8.0",
+ "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -1292,8 +1358,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel 0.5.0",
- "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-deque",
+ "crossbeam-utils 0.8.2",
  "lazy_static",
  "num_cpus",
 ]
@@ -1306,9 +1372,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
@@ -1380,7 +1446,7 @@ dependencies = [
  "base64",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.2",
 ]
 
 [[package]]
@@ -1390,16 +1456,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1434,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.6.2"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fa8fb0da0bf5aa7dd5d8fe1f9ec769833eb7cf97ff89942903809e600de908"
+checksum = "b44be9227e214a0420707c9ca74c2d4991d9955bae9415a8f93f05cebf561be5"
 dependencies = [
  "serde",
  "serde_with_macros",
@@ -1444,15 +1546,21 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1197ff7de45494f290c1e3e1a6f80e108974681984c87a3e480991ef3d0f1950"
+checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
 dependencies = [
- "darling",
+ "darling 0.12.1",
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sharded-slab"
@@ -1490,10 +1598,11 @@ dependencies = [
 
 [[package]]
 name = "skim"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac8dcb2f57eba70ce16c6844af6caa63dc642d404630aae5dc3b4cb48353962"
+checksum = "4b9d19f904221fab15163486d2ce116cb86e60296470bb4e956d6687f04ebbb4"
 dependencies = [
+ "atty",
  "beef",
  "bitflags",
  "chrono",
@@ -1501,15 +1610,15 @@ dependencies = [
  "crossbeam",
  "defer-drop",
  "derive_builder",
- "env_logger 0.6.2",
+ "env_logger 0.8.3",
  "fuzzy-matcher",
  "lazy_static",
  "log",
- "nix",
+ "nix 0.19.1",
  "rayon",
  "regex",
  "shlex",
- "time",
+ "time 0.2.25",
  "timer",
  "tuikit",
  "unicode-width",
@@ -1561,6 +1670,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "standback"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2beb4d1860a61f571530b3f855a1b538d0200f7871c63331ecd6f17b1f014f8"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1738,12 @@ name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
@@ -1616,7 +1789,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand",
- "redox_syscall 0.2.4",
+ "redox_syscall 0.2.5",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -1651,18 +1824,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1686,6 +1859,44 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1195b046942c221454c2539395f85413b33383a067449d78aab2b7b052a142f7"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
 ]
 
 [[package]]
@@ -1778,7 +1989,7 @@ dependencies = [
  "http-body",
  "hyper",
  "percent-encoding",
- "pin-project 1.0.5",
+ "pin-project",
  "prost",
  "prost-derive",
  "tokio",
@@ -1804,18 +2015,19 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd7b451959622e21de79261673d658a0944b835012c58c51878ea55957fb51a"
+checksum = "713c629c07a3a97f741c140e474e7304294fabec66a43a33f0832e98315ab07f"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 1.0.5",
+ "pin-project",
  "rand",
  "slab",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1835,9 +2047,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
+checksum = "f77d3842f76ca899ff2dbcf231c5c65813dea431301d6eb686279c15c4464f12"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -1848,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1868,11 +2080,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-futures"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project",
  "tracing",
 ]
 
@@ -1888,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -1909,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -1937,14 +2149,14 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tuikit"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b14d0a62e5faec84af47c1e7804ff49092c6f05b890f52502928a45d9bbc6c1"
+checksum = "8c628cfc5752254a33ebccf73eb79ef6508fab77de5d5ef76246b5e45010a51f"
 dependencies = [
  "bitflags",
  "lazy_static",
  "log",
- "nix",
+ "nix 0.14.1",
  "term",
  "unicode-width",
 ]
@@ -1969,9 +2181,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "utf8parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "vec_map"
@@ -1993,11 +2205,23 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vte"
-version = "0.3.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf"
+checksum = "6e7745610024d50ab1ebfa41f8f8ee361c567f7ab51032f93cc1cc4cbf0c547a"
 dependencies = [
+ "arrayvec",
  "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -2021,6 +2245,60 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
 
 [[package]]
 name = "which"
@@ -2079,27 +2357,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-wsapoll"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "x11-clipboard"
-version = "0.6.0"
-source = "git+https://github.com/xrelkd/x11-clipboard?tag=v0.6.0#de648ede312e6b236e3b92119a014cac064b9e38"
-dependencies = [
- "xcb",
-]
-
-[[package]]
-name = "xcb"
-version = "0.9.0"
+name = "x11rb"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62056f63138b39116f82a540c983cc11f1c90cd70b3d492a70c25eaa50bd22a6"
+checksum = "a4122702a684f01cf35cf8e00d0ba513f7c4c7d46f9881d9a699f3de787e61e4"
 dependencies = [
- "libc",
- "log",
+ "gethostname",
+ "nix 0.19.1",
+ "winapi 0.3.9",
+ "winapi-wsapoll",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "clipcat"
 version = "0.5.0"
-authors = ["xrelkd 46590321+xrelkd@users.noreply.github.com"]
+authors = ["xrelkd <46590321+xrelkd@users.noreply.github.com>"]
 edition = "2018"
 
 [features]
+default = ["all"]
 all = ["clipcatd", "clipcatctl", "clipcat-menu", "clipcat-notify"]
-default = ["clipcatd", "clipcatctl", "clipcat-menu"]
 
 app = ["app_dirs", "structopt", "toml", "tracing-subscriber", "tracing-futures"]
-monitor = ["x11-clipboard"]
+monitor = ["caracal/x11"]
 daemon = [
   "daemonize", "libc",
   "tracing-subscriber", "tracing-journald",
@@ -58,6 +58,8 @@ tonic = "0.4"
 prost = "0.7"
 http = "0.2"
 
+mime = "0.3"
+
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", optional = true }
 tracing-journald = { version = "0.1", optional = true }
@@ -71,7 +73,7 @@ serde = { version = "1", features = ["derive"] }
 serde_with = "1"
 serde_json = { version = "1", optional = true }
 
-x11-clipboard = { git = "https://github.com/xrelkd/x11-clipboard", tag = "v0.6.0", optional = true }
+caracal = { git = "https://github.com/xrelkd/caracal.git", tag = "v0.1.0", optional = true }
 
 rocksdb = { version = "0.15", optional = true }
 bincode = { version = "1", optional = true }

--- a/proto/manager.proto
+++ b/proto/manager.proto
@@ -6,10 +6,7 @@ service Manager {
   rpc List(ListRequest) returns (ListResponse);
 
   rpc Get(GetRequest) returns (GetResponse);
-  rpc GetCurrentClipboard(GetCurrentClipboardRequest)
-      returns (GetCurrentClipboardResponse);
-  rpc GetCurrentPrimary(GetCurrentPrimaryRequest)
-      returns (GetCurrentPrimaryResponse);
+  rpc GetCurrentClip(GetCurrentClipRequest) returns (GetCurrentClipResponse);
 
   rpc Remove(RemoveRequest) returns (RemoveResponse);
   rpc BatchRemove(BatchRemoveRequest) returns (BatchRemoveResponse);
@@ -18,56 +15,55 @@ service Manager {
   rpc Insert(InsertRequest) returns (InsertResponse);
   rpc Update(UpdateRequest) returns (UpdateResponse);
 
-  rpc MarkAsClipboard(MarkAsClipboardRequest) returns (MarkAsClipboardResponse);
-  rpc MarkAsPrimary(MarkAsPrimaryRequest) returns (MarkAsPrimaryResponse);
+  rpc Mark(MarkRequest) returns (MarkResponse);
 
   rpc Length(LengthRequest) returns (LengthResponse);
 }
 
-enum ClipboardType {
+enum ClipboardMode {
   Clipboard = 0;
-  Primary = 1;
+  Selection = 1;
 }
 
 message ClipboardData {
   uint64 id = 1;
-  string data = 2;
-  ClipboardType clipboard_type = 3;
-  uint64 timestamp = 4;
+  bytes data = 2;
+  string mime = 3;
+  ClipboardMode mode = 4;
+  uint64 timestamp = 5;
 }
 
 message InsertRequest {
-  ClipboardType clipboard_type = 1;
-  string data = 2;
+  ClipboardMode mode = 1;
+  bytes data = 2;
+  string mime = 3;
 }
 message InsertResponse { uint64 id = 1; }
 
 message GetRequest { uint64 id = 1; }
 message GetResponse { ClipboardData data = 1; }
 
-message GetCurrentClipboardRequest {}
-message GetCurrentClipboardResponse { ClipboardData data = 1; }
-
-message GetCurrentPrimaryRequest {}
-message GetCurrentPrimaryResponse { ClipboardData data = 1; }
+message GetCurrentClipRequest { ClipboardMode mode = 1; }
+message GetCurrentClipResponse { ClipboardData data = 1; }
 
 message ListRequest {}
 message ListResponse { repeated ClipboardData data = 1; }
 
 message UpdateRequest {
   uint64 id = 1;
-  string data = 2;
+  bytes data = 2;
+  string mime = 3;
 }
 message UpdateResponse {
   bool ok = 1;
   uint64 new_id = 2;
 }
 
-message MarkAsClipboardRequest { uint64 id = 1; }
-message MarkAsClipboardResponse { bool ok = 1; }
-
-message MarkAsPrimaryRequest { uint64 id = 1; }
-message MarkAsPrimaryResponse { bool ok = 1; }
+message MarkRequest {
+  uint64 id = 1;
+  ClipboardMode mode = 2;
+}
+message MarkResponse { bool ok = 1; }
 
 message LengthRequest {}
 message LengthResponse { uint64 length = 1; }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,4 @@
-stable
+[toolchain]
+channel = "stable"
+components = [ "rustfmt", "clippy" ]
+targets = [ "x86_64-unknown-linux-gnu" ]

--- a/shell.nix
+++ b/shell.nix
@@ -15,9 +15,9 @@ pkgs.mkShell {
     python3
   ];
 
-  buildInputs = with pkgs; [ xorg.libxcb ];
+  buildInputs = with pkgs; [ ];
 
-  RUST_BACKTRACE = 1;
+  RUST_BACKTRACE = "full";
 
   LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib";
 

--- a/src/bin/clipcat-menu/finder/finder_stream.rs
+++ b/src/bin/clipcat-menu/finder/finder_stream.rs
@@ -40,7 +40,7 @@ pub trait FinderStream: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use clipcat::ClipboardData;
+    use clipcat::{ClipboardData, ClipboardMode};
 
     use crate::finder::FinderStream;
 
@@ -49,19 +49,20 @@ mod tests {
 
     #[test]
     fn test_generate_input() {
+        const MODE: ClipboardMode = ClipboardMode::Clipboard;
         let d = Dummy;
         let clips = vec![];
         let v = d.generate_input(&clips);
         assert_eq!(v, "");
 
-        let clips = vec![ClipboardData::new_clipboard("abcde")];
+        let clips = vec![ClipboardData::from_string("abcde", MODE)];
         let v = d.generate_input(&clips);
         assert_eq!(v, "0: abcde");
 
         let clips = vec![
-            ClipboardData::new_clipboard("abcde"),
-            ClipboardData::new_clipboard("АбВГД"),
-            ClipboardData::new_clipboard("あいうえお"),
+            ClipboardData::from_string("abcde", MODE),
+            ClipboardData::from_string("АбВГД", MODE),
+            ClipboardData::from_string("あいうえお", MODE),
         ];
 
         let v = d.generate_input(&clips);

--- a/src/bin/clipcatd/error.rs
+++ b/src/bin/clipcatd/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     #[snafu(display("Could not load config error: {}", source))]
     LoadConfig { source: ConfigError },
 
+    #[snafu(display("Could not create clipboard driver, error: {}", source))]
+    CreateClipboardDriver { source: clipcat::ClipboardError },
+
     #[snafu(display("Could not create HistoryManager, error: {}", source))]
     CreateHistoryManager { source: HistoryError },
 

--- a/src/driver/mock.rs
+++ b/src/driver/mock.rs
@@ -1,0 +1,102 @@
+use caracal::{ClipboardLoad, ClipboardStore, ClipboardSubscribe, MimeData, MockClipboard};
+use snafu::ResultExt;
+use tokio::task;
+
+use crate::{
+    driver::{
+        ClearFuture, ClipboardDriver, ClipboardMode, LoadFuture, LoadMimeDataFuture, StoreFuture,
+        Subscriber,
+    },
+    error, ClipboardError,
+};
+
+#[derive(Clone, Default, Debug)]
+pub struct MockClipboardDriver(MockClipboard);
+
+impl MockClipboardDriver {
+    pub fn new() -> MockClipboardDriver { MockClipboardDriver::default() }
+}
+
+impl ClipboardDriver for MockClipboardDriver {
+    #[inline]
+    fn load(&self, mime: &mime::Mime, _mode: ClipboardMode) -> LoadFuture {
+        let clipboard = self.0.clone();
+        let mime = mime.clone();
+        Box::pin(async move {
+            let data = task::spawn_blocking(move || match clipboard.load(&mime) {
+                Ok(d) => Ok(d),
+                Err(caracal::Error::Empty) => Err(ClipboardError::EmptyClipboard),
+                Err(caracal::Error::MatchMime { expected_mime }) => {
+                    Err(ClipboardError::MatchMime { expected_mime })
+                }
+                Err(caracal::Error::UnknownContentType) => Err(ClipboardError::UnknownContentType),
+                Err(source) => Err(ClipboardError::LoadDataFromX11Clipboard { source }),
+            })
+            .await
+            .context(error::SpawnBlockingTask)??;
+            Ok(data)
+        })
+    }
+
+    #[inline]
+    fn load_mime_data(&self, _mode: ClipboardMode) -> LoadMimeDataFuture {
+        let clipboard = self.0.clone();
+        Box::pin(async move {
+            let data = task::spawn_blocking(move || match clipboard.load_mime_data() {
+                Ok(d) => Ok(d),
+                Err(caracal::Error::Empty) => Err(ClipboardError::EmptyClipboard),
+                Err(caracal::Error::MatchMime { expected_mime }) => {
+                    Err(ClipboardError::MatchMime { expected_mime })
+                }
+                Err(caracal::Error::UnknownContentType) => Err(ClipboardError::UnknownContentType),
+                Err(source) => Err(ClipboardError::LoadDataFromX11Clipboard { source }),
+            })
+            .await
+            .context(error::SpawnBlockingTask)??;
+            Ok(data)
+        })
+    }
+
+    #[inline]
+    fn store(&self, mime: mime::Mime, data: &[u8], _mode: ClipboardMode) -> StoreFuture {
+        let clipboard = self.0.clone();
+        let data = MimeData::new(mime, data.into());
+        Box::pin(async move {
+            task::spawn_blocking(move || clipboard.store_mime_data(data))
+                .await
+                .context(error::SpawnBlockingTask)?
+                .context(error::StoreDataToX11Clipboard)?;
+            Ok(())
+        })
+    }
+
+    #[inline]
+    fn store_mime_data(&self, data: MimeData, _mode: ClipboardMode) -> StoreFuture {
+        let clipboard = self.0.clone();
+        Box::pin(async move {
+            task::spawn_blocking(move || clipboard.store_mime_data(data))
+                .await
+                .context(error::SpawnBlockingTask)?
+                .context(error::StoreDataToX11Clipboard)?;
+            Ok(())
+        })
+    }
+
+    #[inline]
+    fn clear(&self, _mode: ClipboardMode) -> ClearFuture {
+        let clipboard = self.0.clone();
+        Box::pin(async move {
+            task::spawn_blocking(move || clipboard.clear())
+                .await
+                .context(error::SpawnBlockingTask)?
+                .context(error::ClearX11Clipboard)?;
+            Ok(())
+        })
+    }
+
+    #[inline]
+    fn subscribe(&self) -> Result<Subscriber, ClipboardError> {
+        let sub = self.0.subscribe().context(error::SubscribeX11Clipboard)?;
+        Ok(Subscriber::from(vec![sub]))
+    }
+}

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,0 +1,72 @@
+use std::{pin::Pin, sync::Arc};
+
+use futures::Future;
+use tokio::{sync::mpsc, task};
+
+use caracal::{ClipboardWait, MimeData};
+
+use crate::{ClipboardError, ClipboardMode};
+
+mod mock;
+mod x11;
+
+pub use self::{mock::MockClipboardDriver, x11::X11ClipboardDriver};
+
+pub fn new() -> Result<Box<dyn ClipboardDriver>, ClipboardError> {
+    Ok(Box::new(X11ClipboardDriver::new(None)?))
+}
+
+pub fn new_shared() -> Result<Arc<dyn ClipboardDriver>, ClipboardError> {
+    Ok(Arc::new(X11ClipboardDriver::new(None)?))
+}
+
+#[derive(Debug)]
+pub struct Subscriber {
+    receiver: mpsc::UnboundedReceiver<ClipboardMode>,
+    join_handles: Vec<task::JoinHandle<()>>,
+}
+
+impl From<Vec<caracal::Subscriber>> for Subscriber {
+    fn from(subs: Vec<caracal::Subscriber>) -> Subscriber {
+        let (sender, receiver) = mpsc::unbounded_channel();
+
+        let join_handles = subs
+            .into_iter()
+            .map(|subscriber| {
+                let event_sender = sender.clone();
+                task::spawn_blocking(move || {
+                    while let Ok(mode) = subscriber.wait() {
+                        if event_sender.is_closed() {
+                            break;
+                        }
+
+                        if let Err(_err) = event_sender.send(mode.into()) {
+                            break;
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        Subscriber { receiver, join_handles }
+    }
+}
+
+impl Subscriber {
+    pub async fn next(&mut self) -> Option<ClipboardMode> { self.receiver.recv().await }
+}
+
+type LoadFuture = Pin<Box<dyn Future<Output = Result<Vec<u8>, ClipboardError>> + Send + 'static>>;
+type LoadMimeDataFuture =
+    Pin<Box<dyn Future<Output = Result<MimeData, ClipboardError>> + Send + 'static>>;
+type StoreFuture = Pin<Box<dyn Future<Output = Result<(), ClipboardError>> + Send + 'static>>;
+type ClearFuture = Pin<Box<dyn Future<Output = Result<(), ClipboardError>> + Send + 'static>>;
+
+pub trait ClipboardDriver: Sync + Send {
+    fn load(&self, mime: &mime::Mime, mode: ClipboardMode) -> LoadFuture;
+    fn load_mime_data(&self, mode: ClipboardMode) -> LoadMimeDataFuture;
+    fn store(&self, mime: mime::Mime, data: &[u8], mode: ClipboardMode) -> StoreFuture;
+    fn store_mime_data(&self, data: MimeData, mode: ClipboardMode) -> StoreFuture;
+    fn clear(&self, mode: ClipboardMode) -> ClearFuture;
+    fn subscribe(&self) -> Result<Subscriber, ClipboardError>;
+}

--- a/src/driver/x11.rs
+++ b/src/driver/x11.rs
@@ -1,0 +1,130 @@
+use std::sync::Arc;
+
+use caracal::{ClipboardLoad, ClipboardStore, ClipboardSubscribe, MimeData, Mode, X11Clipboard};
+use snafu::ResultExt;
+use tokio::task;
+
+use crate::{
+    driver::{
+        ClearFuture, ClipboardDriver, ClipboardMode, LoadFuture, LoadMimeDataFuture, StoreFuture,
+        Subscriber,
+    },
+    error, ClipboardError,
+};
+
+#[derive(Debug, Clone)]
+pub struct X11ClipboardDriver {
+    default_clipboard: Arc<X11Clipboard>,
+    primary_clipboard: Arc<X11Clipboard>,
+}
+
+impl X11ClipboardDriver {
+    pub fn new(display_name: Option<&str>) -> Result<X11ClipboardDriver, ClipboardError> {
+        let default_clipboard = X11Clipboard::new(display_name, Mode::Clipboard)
+            .context(error::InitializeX11Clipboard)?;
+        let primary_clipboard = X11Clipboard::new(display_name, Mode::Selection)
+            .context(error::InitializeX11Clipboard)?;
+        Ok(X11ClipboardDriver {
+            default_clipboard: Arc::new(default_clipboard),
+            primary_clipboard: Arc::new(primary_clipboard),
+        })
+    }
+
+    #[inline]
+    fn select_clipboard(&self, mode: ClipboardMode) -> Arc<X11Clipboard> {
+        match mode {
+            ClipboardMode::Clipboard => Arc::clone(&self.default_clipboard),
+            ClipboardMode::Selection => Arc::clone(&self.primary_clipboard),
+        }
+    }
+}
+
+impl ClipboardDriver for X11ClipboardDriver {
+    #[inline]
+    fn load(&self, mime: &mime::Mime, mode: ClipboardMode) -> LoadFuture {
+        let clipboard = self.select_clipboard(mode);
+        let mime = mime.clone();
+        Box::pin(async move {
+            let data = task::spawn_blocking(move || match clipboard.load(&mime) {
+                Ok(d) => Ok(d),
+                Err(caracal::Error::Empty) => Err(ClipboardError::EmptyClipboard),
+                Err(caracal::Error::MatchMime { expected_mime }) => {
+                    Err(ClipboardError::MatchMime { expected_mime })
+                }
+                Err(caracal::Error::UnknownContentType) => Err(ClipboardError::UnknownContentType),
+                Err(source) => Err(ClipboardError::LoadDataFromX11Clipboard { source }),
+            })
+            .await
+            .context(error::SpawnBlockingTask)??;
+            Ok(data)
+        })
+    }
+
+    #[inline]
+    fn load_mime_data(&self, mode: ClipboardMode) -> LoadMimeDataFuture {
+        let clipboard = self.select_clipboard(mode);
+        Box::pin(async move {
+            let data = task::spawn_blocking(move || match clipboard.load_mime_data() {
+                Ok(d) => Ok(d),
+                Err(caracal::Error::Empty) => Err(ClipboardError::EmptyClipboard),
+                Err(caracal::Error::MatchMime { expected_mime }) => {
+                    Err(ClipboardError::MatchMime { expected_mime })
+                }
+                Err(caracal::Error::UnknownContentType) => Err(ClipboardError::UnknownContentType),
+                Err(source) => Err(ClipboardError::LoadDataFromX11Clipboard { source }),
+            })
+            .await
+            .context(error::SpawnBlockingTask)??;
+            Ok(data)
+        })
+    }
+
+    #[inline]
+    fn store(&self, mime: mime::Mime, data: &[u8], mode: ClipboardMode) -> StoreFuture {
+        let clipboard = self.select_clipboard(mode);
+        let data = MimeData::new(mime, data.into());
+        Box::pin(async move {
+            task::spawn_blocking(move || clipboard.store_mime_data(data))
+                .await
+                .context(error::SpawnBlockingTask)?
+                .context(error::StoreDataToX11Clipboard)?;
+            Ok(())
+        })
+    }
+
+    #[inline]
+    fn store_mime_data(&self, data: MimeData, mode: ClipboardMode) -> StoreFuture {
+        let clipboard = self.select_clipboard(mode);
+        Box::pin(async move {
+            task::spawn_blocking(move || clipboard.store_mime_data(data))
+                .await
+                .context(error::SpawnBlockingTask)?
+                .context(error::StoreDataToX11Clipboard)?;
+            Ok(())
+        })
+    }
+
+    #[inline]
+    fn clear(&self, mode: ClipboardMode) -> ClearFuture {
+        let clipboard = self.select_clipboard(mode);
+        Box::pin(async move {
+            task::spawn_blocking(move || clipboard.clear())
+                .await
+                .context(error::SpawnBlockingTask)?
+                .context(error::ClearX11Clipboard)?;
+            Ok(())
+        })
+    }
+
+    #[inline]
+    fn subscribe(&self) -> Result<Subscriber, ClipboardError> {
+        let mut subs = Vec::with_capacity(2);
+        for mode in &[ClipboardMode::Clipboard, ClipboardMode::Selection] {
+            let clipboard = self.select_clipboard(*mode);
+            let sub = clipboard.subscribe().context(error::SubscribeX11Clipboard)?;
+            subs.push(sub);
+        }
+
+        Ok(Subscriber::from(subs))
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,11 +4,39 @@ pub enum ClipboardError {
     #[snafu(display("Could not spawn tokio task, error: {}", source))]
     SpawnBlockingTask { source: tokio::task::JoinError },
 
-    #[cfg(feature = "monitor")]
-    #[snafu(display("Could not initialize X11 clipboard, error: {}", source))]
-    InitializeX11Clipboard { source: x11_clipboard::error::Error },
+    #[snafu(display("Could not send clipboard event"))]
+    SendClipboardEvent,
+
+    #[snafu(display("Clipboard is empty"))]
+    EmptyClipboard,
+
+    #[snafu(display("Content type is not matched, expected: {}", expected_mime.essence_str()))]
+    MatchMime { expected_mime: mime::Mime },
+
+    #[snafu(display("Unknown Content type"))]
+    UnknownContentType,
 
     #[cfg(feature = "monitor")]
-    #[snafu(display("Could not paste to X11 clipboard, error: {}", source))]
-    PasteToX11Clipboard { source: x11_clipboard::error::Error },
+    #[snafu(display("Could not initialize X11 clipboard, error: {}", source))]
+    InitializeX11Clipboard { source: caracal::Error },
+
+    #[cfg(feature = "monitor")]
+    #[snafu(display("Could not clear X11 clipboard, error: {}", source))]
+    ClearX11Clipboard { source: caracal::Error },
+
+    #[cfg(feature = "monitor")]
+    #[snafu(display("Could not store data to X11 clipboard, error: {}", source))]
+    StoreDataToX11Clipboard { source: caracal::Error },
+
+    #[cfg(feature = "monitor")]
+    #[snafu(display("Could not load data from X11 clipboard, error: {}", source))]
+    LoadDataFromX11Clipboard { source: caracal::Error },
+
+    #[cfg(feature = "monitor")]
+    #[snafu(display("Could not subscribe X11 clipboard, error: {}", source))]
+    SubscribeX11Clipboard { source: caracal::Error },
+
+    #[cfg(feature = "monitor")]
+    #[snafu(display("Subscriber is closed"))]
+    SubscriberClosed,
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,28 +3,29 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use crate::{ClipboardData, ClipboardType};
+use caracal::MimeData;
+
+use crate::{ClipboardData, ClipboardMode};
 
 #[derive(Debug, Clone, Eq)]
 pub struct ClipboardEvent {
-    pub data: String,
-    pub clipboard_type: ClipboardType,
+    pub data: Vec<u8>,
+    pub mime: mime::Mime,
+    pub mode: ClipboardMode,
 }
 
 impl ClipboardEvent {
-    pub fn new_clipboard<S: ToString>(data: S) -> ClipboardEvent {
-        ClipboardEvent { data: data.to_string(), clipboard_type: ClipboardType::Clipboard }
-    }
-
-    pub fn new_primary<S: ToString>(data: S) -> ClipboardEvent {
-        ClipboardEvent { data: data.to_string(), clipboard_type: ClipboardType::Primary }
+    #[inline]
+    pub fn new(data: MimeData, mode: ClipboardMode) -> ClipboardEvent {
+        let (mime, data) = data.destruct();
+        ClipboardEvent { data, mime, mode }
     }
 }
 
 impl From<ClipboardData> for ClipboardEvent {
     fn from(data: ClipboardData) -> ClipboardEvent {
-        let ClipboardData { data, clipboard_type, .. } = data;
-        ClipboardEvent { data, clipboard_type }
+        let ClipboardData { data, mime, mode, .. } = data;
+        ClipboardEvent { data, mime, mode }
     }
 }
 
@@ -37,7 +38,7 @@ impl PartialOrd for ClipboardEvent {
 }
 
 impl Ord for ClipboardEvent {
-    fn cmp(&self, other: &Self) -> Ordering { self.clipboard_type.cmp(&other.clipboard_type) }
+    fn cmp(&self, other: &Self) -> Ordering { self.mode.cmp(&other.mode) }
 }
 
 impl Hash for ClipboardEvent {


### PR DESCRIPTION
  - drop `x11-clipboard`
  - add `ClipboardDriver` trait for integrating with `caracal`
  - apply `caracal` for storing contents of clipboard
  - apply `caracal` for loading contents of clipboard
  - apply `caracal` for watch new event clipboard
  - support MIME type while loading/storing clipboard