### PR TITLE
build(deps): add `fs` feature for `tokio`

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1"
 async-trait  = "0.1"
 futures      = "0.3"
 sigfinn      = "0.1"
-tokio        = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+tokio        = { version = "1", features = ["rt-multi-thread", "macros", "sync" , "fs"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 
 tonic = { version = "0.10", features = ["gzip"] }


### PR DESCRIPTION
Hey,
i was trying to compile the project with instuction on READNE when i had error about tokio::fs
```
failed to resolve: could not find `fs` in `tokio`
```
it turns out you have to enable[ this feature in tokio](https://docs.rs/tokio/latest/tokio/fs/index.html) to be able to use it.
tokio::fs is been used in [here](https://github.com/xrelkd/clipcat/blob/5034244140a3142c286216c419dadfa3318e6aa2/crates/server/src/lib.rs#L139C14-L139C14), so i added to its Cargo.toml