### PR TITLE
Get `clipcatd` Version from gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "image",
  "lazy_static",
  "mime",
+ "semver",
  "serde",
  "snafu",
  "time",
@@ -648,6 +649,7 @@ dependencies = [
  "http 1.0.0",
  "mime",
  "prost-types",
+ "semver",
  "snafu",
  "tokio",
  "tonic",
@@ -745,9 +747,11 @@ dependencies = [
  "clipcat-clipboard",
  "clipcat-proto",
  "futures",
+ "lazy_static",
  "mime",
  "notify-rust",
  "parking_lot",
+ "semver",
  "serde",
  "serde_json",
  "sigfinn",
@@ -2659,6 +2663,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -22,6 +22,7 @@ humansize   = "2"
 image       = "0.24"
 lazy_static = "1"
 mime        = "0.3"
+semver      = "1"
 snafu       = "0.7"
 time        = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
 

--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -11,12 +11,26 @@ use std::{
 
 use bytes::Bytes;
 use directories::ProjectDirs;
+use lazy_static::lazy_static;
 
 pub use self::{
     entry::{Entry as ClipEntry, Error as ClipEntryError, Metadata as ClipEntryMetadata},
     kind::Kind as ClipboardKind,
     watcher_state::WatcherState as ClipboardWatcherState,
 };
+
+pub const PROJECT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+lazy_static! {
+    pub static ref PROJECT_SEMVER: semver::Version = semver::Version::parse(PROJECT_VERSION)
+        .unwrap_or(semver::Version {
+            major: 0,
+            minor: 0,
+            patch: 0,
+            pre: semver::Prerelease::EMPTY,
+            build: semver::BuildMetadata::EMPTY
+        });
+}
 
 pub const PROJECT_NAME: &str = "clipcat";
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -23,8 +23,9 @@ tower = "0.4"
 tonic       = { version = "0.10", features = ["gzip"] }
 prost-types = "0.12"
 
-snafu = "0.7"
-mime  = "0.3"
+mime   = "0.3"
+semver = "1"
+snafu  = "0.7"
 
 clipcat-base  = { path = "../base" }
 clipcat-proto = { path = "../proto" }

--- a/crates/client/src/error.rs
+++ b/crates/client/src/error.rs
@@ -217,3 +217,16 @@ impl fmt::Display for GetWatcherStateError {
         }
     }
 }
+
+#[derive(Debug)]
+pub enum GetSystemVersionError {
+    Status { source: tonic::Status },
+}
+
+impl fmt::Display for GetSystemVersionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Status { source } => source.fmt(f),
+        }
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 mod manager;
+mod system;
 mod watcher;
 
 use std::path::Path;
@@ -10,6 +11,7 @@ use tokio::net::UnixStream;
 pub use self::{
     error::{Error, Result},
     manager::Manager,
+    system::System,
     watcher::Watcher,
 };
 

--- a/crates/client/src/system.rs
+++ b/crates/client/src/system.rs
@@ -1,0 +1,29 @@
+use async_trait::async_trait;
+use clipcat_proto as proto;
+use tonic::Request;
+
+use crate::{error::GetSystemVersionError, Client};
+
+#[async_trait]
+pub trait System {
+    async fn get_version(&self) -> Result<semver::Version, GetSystemVersionError>;
+}
+
+#[async_trait]
+impl System for Client {
+    async fn get_version(&self) -> Result<semver::Version, GetSystemVersionError> {
+        let proto::GetSystemVersionResponse { major, minor, patch } =
+            proto::SystemClient::new(self.channel.clone())
+                .get_version(Request::new(()))
+                .await
+                .map_err(|source| GetSystemVersionError::Status { source })?
+                .into_inner();
+        Ok(semver::Version {
+            major,
+            minor,
+            patch,
+            pre: semver::Prerelease::EMPTY,
+            build: semver::BuildMetadata::EMPTY,
+        })
+    }
+}

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -10,7 +10,7 @@ fn prost_config() -> Config {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure().compile_with_config(
         prost_config(),
-        &["proto/manager.proto", "proto/watcher.proto"],
+        &["proto/manager.proto", "proto/system.proto", "proto/watcher.proto"],
         &["proto/"],
     )?;
     Ok(())

--- a/crates/proto/proto/system.proto
+++ b/crates/proto/proto/system.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package clipcat;
+
+import "google/protobuf/empty.proto";
+
+service System {
+  rpc GetVersion(google.protobuf.Empty) returns (GetSystemVersionResponse);
+}
+
+message GetSystemVersionResponse {
+  uint64 major = 1;
+  uint64 minor = 2;
+  uint64 patch = 3;
+}

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -31,17 +31,20 @@ use time::OffsetDateTime;
 pub use self::proto::{
     manager_client::ManagerClient,
     manager_server::{Manager, ManagerServer},
+    system_client::SystemClient,
+    system_server::{System, SystemServer},
     watcher_client::WatcherClient,
     watcher_server::{Watcher, WatcherServer},
     BatchRemoveRequest, BatchRemoveResponse, ClipEntry, ClipEntryMetadata, ClipboardKind,
-    GetCurrentClipRequest, GetCurrentClipResponse, GetRequest, GetResponse, InsertRequest,
-    InsertResponse, LengthResponse, ListRequest, ListResponse, MarkRequest, MarkResponse,
-    RemoveRequest, RemoveResponse, UpdateRequest, UpdateResponse, WatcherState, WatcherStateReply,
+    GetCurrentClipRequest, GetCurrentClipResponse, GetRequest, GetResponse,
+    GetSystemVersionResponse, InsertRequest, InsertResponse, LengthResponse, ListRequest,
+    ListResponse, MarkRequest, MarkResponse, RemoveRequest, RemoveResponse, UpdateRequest,
+    UpdateResponse, WatcherState, WatcherStateReply,
 };
 
 impl From<ClipboardKind> for clipcat_base::ClipboardKind {
-    fn from(t: ClipboardKind) -> Self {
-        match t {
+    fn from(kind: ClipboardKind) -> Self {
+        match kind {
             ClipboardKind::Clipboard => Self::Clipboard,
             ClipboardKind::Primary => Self::Primary,
             ClipboardKind::Secondary => Self::Secondary,
@@ -50,8 +53,8 @@ impl From<ClipboardKind> for clipcat_base::ClipboardKind {
 }
 
 impl From<clipcat_base::ClipboardKind> for ClipboardKind {
-    fn from(t: clipcat_base::ClipboardKind) -> Self {
-        match t {
+    fn from(kind: clipcat_base::ClipboardKind) -> Self {
+        match kind {
             clipcat_base::ClipboardKind::Clipboard => Self::Clipboard,
             clipcat_base::ClipboardKind::Primary => Self::Primary,
             clipcat_base::ClipboardKind::Secondary => Self::Secondary,

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -31,9 +31,11 @@ tokio-stream = { version = "0.1", features = ["net"] }
 
 tonic = { version = "0.10", features = ["gzip"] }
 
+lazy_static = "1"
 mime = "0.3"
 notify-rust = "4"
 parking_lot = "0.12"
+semver = "1"
 snafu = "0.7"
 time = { version = "0.3", features = [
   "formatting",

--- a/crates/server/src/backend/default.rs
+++ b/crates/server/src/backend/default.rs
@@ -6,14 +6,14 @@ use clipcat_clipboard::{Clipboard, ClipboardLoad, ClipboardStore, ClipboardSubsc
 use snafu::ResultExt;
 use tokio::task;
 
-use crate::backend::{error, ClipboardBackend, Error, Result, Subscriber};
+use crate::backend::{error, traits, Error, Result, Subscriber};
 
 #[derive(Clone)]
-pub struct DefaultClipboardBackend {
+pub struct Backend {
     clipboards: Vec<Arc<Clipboard>>,
 }
 
-impl DefaultClipboardBackend {
+impl Backend {
     /// # Errors
     pub fn new() -> Result<Self> {
         let mut clipboards = Vec::with_capacity(ClipboardKind::MAX_LENGTH);
@@ -43,7 +43,7 @@ impl DefaultClipboardBackend {
 }
 
 #[async_trait]
-impl ClipboardBackend for DefaultClipboardBackend {
+impl traits::Backend for Backend {
     #[inline]
     async fn load(
         &self,

--- a/crates/server/src/backend/mock.rs
+++ b/crates/server/src/backend/mock.rs
@@ -4,18 +4,18 @@ use clipcat_clipboard::{ClipboardLoad, ClipboardStore, ClipboardSubscribe, MockC
 use snafu::ResultExt;
 use tokio::task;
 
-use crate::backend::{error, ClipboardBackend, ClipboardKind, Error, Result, Subscriber};
+use crate::backend::{error, traits, ClipboardKind, Error, Result, Subscriber};
 
 #[derive(Clone, Debug, Default)]
-pub struct MockClipboardBackend(MockClipboard);
+pub struct Backend(MockClipboard);
 
-impl MockClipboardBackend {
+impl Backend {
     #[must_use]
     pub fn new() -> Self { Self::default() }
 }
 
 #[async_trait]
-impl ClipboardBackend for MockClipboardBackend {
+impl traits::Backend for Backend {
     #[inline]
     async fn load(
         &self,

--- a/crates/server/src/backend/mod.rs
+++ b/crates/server/src/backend/mod.rs
@@ -1,85 +1,24 @@
 mod default;
 mod error;
 mod mock;
+mod subscriber;
+mod traits;
 
-use std::{iter::IntoIterator, sync::Arc};
+use std::sync::Arc;
 
-use async_trait::async_trait;
-use clipcat_base::{ClipboardContent, ClipboardKind};
-use clipcat_clipboard::ClipboardWait;
-use tokio::{sync::mpsc, task};
+use clipcat_base::ClipboardKind;
 
 use self::error::Result;
-pub use self::{default::DefaultClipboardBackend, error::Error, mock::MockClipboardBackend};
+pub use self::{
+    default::Backend as DefaultClipboardBackend, error::Error,
+    mock::Backend as MockClipboardBackend, subscriber::Subscriber,
+    traits::Backend as ClipboardBackend,
+};
 
 /// # Errors
-pub fn new() -> Result<Box<dyn ClipboardBackend>> { Ok(Box::new(DefaultClipboardBackend::new()?)) }
+pub fn new() -> Result<Box<dyn traits::Backend>> { Ok(Box::new(DefaultClipboardBackend::new()?)) }
 
 /// # Errors
-pub fn new_shared() -> Result<Arc<dyn ClipboardBackend>> {
+pub fn new_shared() -> Result<Arc<dyn traits::Backend>> {
     Ok(Arc::new(DefaultClipboardBackend::new()?))
-}
-
-#[derive(Debug)]
-pub struct Subscriber {
-    receiver: mpsc::UnboundedReceiver<(ClipboardKind, mime::Mime)>,
-    join_handles: task::JoinSet<()>,
-}
-
-impl<I> From<I> for Subscriber
-where
-    I: IntoIterator<Item = clipcat_clipboard::Subscriber>,
-{
-    fn from(subs: I) -> Self {
-        let (sender, receiver) = mpsc::unbounded_channel();
-
-        let join_handles =
-            subs.into_iter().fold(task::JoinSet::new(), |mut join_handles, subscriber| {
-                let _unused = join_handles.spawn_blocking({
-                    let event_sender = sender.clone();
-                    move || {
-                        while let Ok(kind) = subscriber.wait() {
-                            if event_sender.is_closed() {
-                                break;
-                            }
-
-                            if let Err(_err) = event_sender.send(kind) {
-                                break;
-                            }
-                        }
-                    }
-                });
-                join_handles
-            });
-
-        Self { receiver, join_handles }
-    }
-}
-
-impl Subscriber {
-    pub async fn next(&mut self) -> Option<(ClipboardKind, mime::Mime)> {
-        self.receiver.recv().await
-    }
-}
-
-impl Drop for Subscriber {
-    fn drop(&mut self) {
-        self.receiver.close();
-        self.join_handles.abort_all();
-    }
-}
-
-#[async_trait]
-pub trait ClipboardBackend: Sync + Send {
-    async fn load(&self, kind: ClipboardKind, mime: Option<mime::Mime>)
-        -> Result<ClipboardContent>;
-
-    async fn store(&self, kind: ClipboardKind, data: ClipboardContent) -> Result<()>;
-
-    async fn clear(&self, kind: ClipboardKind) -> Result<()>;
-
-    /// # Errors
-    fn subscribe(&self) -> Result<Subscriber>;
-
-    fn supported_clipboard_kinds(&self) -> Vec<ClipboardKind>;
 }

--- a/crates/server/src/backend/subscriber.rs
+++ b/crates/server/src/backend/subscriber.rs
@@ -1,0 +1,54 @@
+use std::iter::IntoIterator;
+
+use clipcat_base::ClipboardKind;
+use clipcat_clipboard::ClipboardWait;
+use tokio::{sync::mpsc, task};
+
+#[derive(Debug)]
+pub struct Subscriber {
+    receiver: mpsc::UnboundedReceiver<(ClipboardKind, mime::Mime)>,
+    join_handles: task::JoinSet<()>,
+}
+
+impl Subscriber {
+    pub async fn next(&mut self) -> Option<(ClipboardKind, mime::Mime)> {
+        self.receiver.recv().await
+    }
+}
+
+impl Drop for Subscriber {
+    fn drop(&mut self) {
+        self.receiver.close();
+        self.join_handles.abort_all();
+    }
+}
+
+impl<I> From<I> for Subscriber
+where
+    I: IntoIterator<Item = clipcat_clipboard::Subscriber>,
+{
+    fn from(subs: I) -> Self {
+        let (sender, receiver) = mpsc::unbounded_channel();
+
+        let join_handles =
+            subs.into_iter().fold(task::JoinSet::new(), |mut join_handles, subscriber| {
+                let _unused = join_handles.spawn_blocking({
+                    let event_sender = sender.clone();
+                    move || {
+                        while let Ok(kind) = subscriber.wait() {
+                            if event_sender.is_closed() {
+                                break;
+                            }
+
+                            if let Err(_err) = event_sender.send(kind) {
+                                break;
+                            }
+                        }
+                    }
+                });
+                join_handles
+            });
+
+        Self { receiver, join_handles }
+    }
+}

--- a/crates/server/src/backend/traits.rs
+++ b/crates/server/src/backend/traits.rs
@@ -1,0 +1,19 @@
+use async_trait::async_trait;
+use clipcat_base::{ClipboardContent, ClipboardKind};
+
+use crate::backend::{error::Result, Subscriber};
+
+#[async_trait]
+pub trait Backend: Sync + Send {
+    async fn load(&self, kind: ClipboardKind, mime: Option<mime::Mime>)
+        -> Result<ClipboardContent>;
+
+    async fn store(&self, kind: ClipboardKind, data: ClipboardContent) -> Result<()>;
+
+    async fn clear(&self, kind: ClipboardKind) -> Result<()>;
+
+    /// # Errors
+    fn subscribe(&self) -> Result<Subscriber>;
+
+    fn supported_clipboard_kinds(&self) -> Vec<ClipboardKind>;
+}

--- a/crates/server/src/grpc/mod.rs
+++ b/crates/server/src/grpc/mod.rs
@@ -1,4 +1,5 @@
 mod manager;
+mod system;
 mod watcher;
 
-pub use self::{manager::ManagerService, watcher::WatcherService};
+pub use self::{manager::ManagerService, system::SystemService, watcher::WatcherService};

--- a/crates/server/src/grpc/system.rs
+++ b/crates/server/src/grpc/system.rs
@@ -1,0 +1,29 @@
+use clipcat_proto as proto;
+use lazy_static::lazy_static;
+use tonic::{Request, Response, Status};
+
+lazy_static! {
+    static ref GET_SYSTEM_VERSION_RESPONSE: proto::GetSystemVersionResponse =
+        proto::GetSystemVersionResponse {
+            major: clipcat_base::PROJECT_SEMVER.major,
+            minor: clipcat_base::PROJECT_SEMVER.minor,
+            patch: clipcat_base::PROJECT_SEMVER.patch
+        };
+}
+
+pub struct SystemService {}
+
+impl SystemService {
+    #[inline]
+    pub const fn new() -> Self { Self {} }
+}
+
+#[tonic::async_trait]
+impl proto::System for SystemService {
+    async fn get_version(
+        &self,
+        _request: Request<()>,
+    ) -> Result<Response<proto::GetSystemVersionResponse>, Status> {
+        Ok(Response::new(GET_SYSTEM_VERSION_RESPONSE.clone()))
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -10,7 +10,7 @@ mod watcher;
 use std::{future::Future, net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc};
 
 use clipcat_base::ClipEntry;
-use clipcat_proto::{ManagerServer, WatcherServer};
+use clipcat_proto::{ManagerServer, SystemServer, WatcherServer};
 use futures::{FutureExt, StreamExt};
 use notification::Notification;
 use sigfinn::{ExitStatus, Handle, LifecycleManager, Shutdown};
@@ -174,6 +174,7 @@ fn create_grpc_local_socket_server_future(
             };
 
             let result = tonic::transport::Server::builder()
+                .add_service(SystemServer::new(grpc::SystemService::new()))
                 .add_service(WatcherServer::new(grpc::WatcherService::new(
                     clipboard_watcher_toggle,
                 )))
@@ -223,6 +224,7 @@ fn create_grpc_http_server_future(
             tracing::info!("Listen Clipcat gRPC endpoint on {listen_address}");
 
             let result = tonic::transport::Server::builder()
+                .add_service(SystemServer::new(grpc::SystemService::new()))
                 .add_service(WatcherServer::new(grpc::WatcherService::new(
                     clipboard_watcher_toggle,
                 )))


### PR DESCRIPTION
- refactor(crates/server): refactor `backend`
- feat(crates/proto): add `SystemService`
- feat(crates/client): add `System`
- feat(crates/base): add `PROJECT_SEMVER`
- feat(crates/client): add `SystemSystem`
- feat(clipcat-menu): show server version
- feat(clipcatctl): show server version
- build: update `Cargo.lock`
