### PR TITLE
feat(clipcat-menu): pass args from config file to rofi

### DIFF
--- a/clipcat-menu/src/config.rs
+++ b/clipcat-menu/src/config.rs
@@ -84,6 +84,9 @@ pub struct Rofi {
 
     #[serde(default = "default_menu_prompt")]
     pub menu_prompt: String,
+
+    #[serde(default)]
+    pub extra_arguments: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -96,6 +99,9 @@ pub struct Dmenu {
 
     #[serde(default = "default_menu_prompt")]
     pub menu_prompt: String,
+
+    #[serde(default)]
+    pub extra_arguments: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -111,6 +117,7 @@ impl Default for Rofi {
             menu_prompt: default_menu_prompt(),
             menu_length: default_menu_length(),
             line_length: default_line_length(),
+            extra_arguments: Vec::new(),
         }
     }
 }
@@ -121,6 +128,7 @@ impl Default for Dmenu {
             menu_prompt: default_menu_prompt(),
             menu_length: default_menu_length(),
             line_length: default_line_length(),
+            extra_arguments: Vec::new(),
         }
     }
 }

--- a/clipcat-menu/src/finder/external/dmenu.rs
+++ b/clipcat-menu/src/finder/external/dmenu.rs
@@ -8,12 +8,13 @@ pub struct Dmenu {
     menu_length: usize,
     line_length: usize,
     menu_prompt: String,
+    extra_arguments: Vec<String>,
 }
 
 impl From<config::Dmenu> for Dmenu {
     fn from(config: config::Dmenu) -> Self {
-        let config::Dmenu { menu_length, line_length, menu_prompt } = config;
-        Self { menu_length, line_length, menu_prompt }
+        let config::Dmenu { menu_length, line_length, menu_prompt, extra_arguments } = config;
+        Self { menu_length, line_length, menu_prompt, extra_arguments }
     }
 }
 
@@ -21,12 +22,10 @@ impl ExternalProgram for Dmenu {
     fn program(&self) -> String { "dmenu".to_string() }
 
     fn args(&self, _selection_mode: SelectionMode) -> Vec<String> {
-        vec![
-            "-l".to_owned(),
-            self.menu_length.to_string(),
-            "-p".to_owned(),
-            self.menu_prompt.clone(),
-        ]
+        ["-l".to_owned(), self.menu_length.to_string(), "-p".to_owned(), self.menu_prompt.clone()]
+            .into_iter()
+            .chain(self.extra_arguments.clone())
+            .collect()
     }
 }
 

--- a/clipcat-menu/src/finder/external/rofi.rs
+++ b/clipcat-menu/src/finder/external/rofi.rs
@@ -12,11 +12,14 @@ pub struct Rofi {
     line_length: usize,
     menu_length: usize,
     menu_prompt: String,
+    extra_arguments: Vec<String>,
 }
 
 impl From<config::Rofi> for Rofi {
-    fn from(config::Rofi { menu_length, line_length, menu_prompt }: config::Rofi) -> Self {
-        Self { line_length, menu_length, menu_prompt }
+    fn from(
+        config::Rofi { menu_length, line_length, menu_prompt, extra_arguments }: config::Rofi,
+    ) -> Self {
+        Self { line_length, menu_length, menu_prompt, extra_arguments }
     }
 }
 
@@ -24,7 +27,13 @@ impl ExternalProgram for Rofi {
     fn program(&self) -> String { "rofi".to_string() }
 
     fn args(&self, selection_mode: SelectionMode) -> Vec<String> {
-        let common_args = [
+        match selection_mode {
+            SelectionMode::Single => Vec::new(),
+            SelectionMode::Multiple => vec!["-multi-select".to_owned()],
+        }
+        .into_iter()
+        .chain([
+            "-dmenu".to_owned(),
             "-l".to_owned(),
             self.menu_length.to_string(),
             "-sep".to_owned(),
@@ -33,19 +42,9 @@ impl ExternalProgram for Rofi {
             "i".to_owned(),
             "-p".to_owned(),
             self.menu_prompt.clone(),
-        ];
-        match selection_mode {
-            SelectionMode::Single => {
-                let mut args = vec!["-dmenu".to_owned()];
-                args.extend_from_slice(&common_args);
-                args
-            }
-            SelectionMode::Multiple => {
-                let mut args = vec!["-dmenu".to_owned(), "-multi-select".to_owned()];
-                args.extend_from_slice(&common_args);
-                args
-            }
-        }
+        ])
+        .chain(self.extra_arguments.clone())
+        .collect()
     }
 }
 
@@ -82,8 +81,12 @@ mod tests {
     fn test_args() {
         let menu_length = 30;
         let menu_prompt = clipcat_base::DEFAULT_MENU_PROMPT.to_owned();
-        let config =
-            config::Rofi { line_length: 40, menu_length, menu_prompt: menu_prompt.clone() };
+        let config = config::Rofi {
+            line_length: 40,
+            menu_length,
+            menu_prompt: menu_prompt.clone(),
+            extra_arguments: vec!["-mesg".to_owned(), "Please select a clip".to_owned()],
+        };
         let rofi = Rofi::from(config);
         assert_eq!(
             rofi.args(SelectionMode::Single),
@@ -96,14 +99,16 @@ mod tests {
                 "-format".to_owned(),
                 "i".to_owned(),
                 "-p".to_owned(),
-                menu_prompt.clone()
+                menu_prompt.clone(),
+                "-mesg".to_owned(),
+                "Please select a clip".to_owned()
             ]
         );
         assert_eq!(
             rofi.args(SelectionMode::Multiple),
             vec![
-                "-dmenu".to_owned(),
                 "-multi-select".to_owned(),
+                "-dmenu".to_owned(),
                 "-l".to_owned(),
                 menu_length.to_string(),
                 "-sep".to_owned(),
@@ -111,7 +116,9 @@ mod tests {
                 "-format".to_owned(),
                 "i".to_owned(),
                 "-p".to_owned(),
-                menu_prompt
+                menu_prompt,
+                "-mesg".to_owned(),
+                "Please select a clip".to_owned()
             ]
         );
     }


### PR DESCRIPTION
Hey,
this PR allows custom args to be passed to rofi such as theme etc.

Btw, I changed  `SelectionMode` condition, this cause `-dmenu` arg to be at the end of args vec, is it ok ?? Cause the way the code was it seemed it should be on top. But im using the clipcat-menu and there is no problem with it, so I think it's ok. let me know if it can cause any problem.