### PR TITLE
fix(clipcatctl): fix panic while printing preview data to `stdout`

### DIFF
--- a/clipcatctl/src/cli.rs
+++ b/clipcatctl/src/cli.rs
@@ -457,11 +457,8 @@ async fn print_list(client: &Client, preview_length: usize, no_id: bool) -> Resu
     let metadata_list = client.list(preview_length).await?;
     for metadata in metadata_list {
         let ClipEntryMetadata { id, preview, .. } = metadata;
-        if no_id {
-            println!("{preview}");
-        } else {
-            println!("{id:016x}: {preview}");
-        }
+        let output = if no_id { preview } else { format!("{id:016x}: {preview}\n") };
+        tokio::io::stdout().write_all(output.as_bytes()).await.context(error::WriteStdoutSnafu)?;
     }
     Ok(())
 }


### PR DESCRIPTION
Try running `clipcatctl list | head`, it will panic. This is a well known feature of `println!`.