### PR TITLE
feat: primary selection threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ history_file_path = "/home/<username>/.cache/clipcat/clipcatd-history"
 # File path of PID file,
 # if you omit this value, clipcatd places the PID file on `$XDG_RUNTIME_DIR/clipcatd.pid`.
 pid_file = "/run/user/<user-id>/clipcatd.pid"
+# Controls how often the program updates its stored value of the Linux
+# primary selection. In the Linux environment, the primary selection is a
+# mechanism that automatically updates to reflect the current highlighted text or
+# object, typically updating with every mouse movement.
+primary_threshold_ms = 5000
 
 [log]
 # Emit log message to a log file.

--- a/clipcatd/src/config/mod.rs
+++ b/clipcatd/src/config/mod.rs
@@ -26,6 +26,9 @@ pub struct Config {
     #[serde(default = "Config::default_pid_file_path")]
     pub pid_file: PathBuf,
 
+    #[serde(default = "Config::default_primary_threshold_ms")]
+    pub primary_threshold_ms: i64,
+
     #[serde(default = "Config::default_max_history")]
     pub max_history: usize,
 
@@ -62,6 +65,7 @@ impl Default for Config {
         Self {
             daemonize: true,
             pid_file: Self::default_pid_file_path(),
+            primary_threshold_ms: Self::default_primary_threshold_ms(),
             max_history: Self::default_max_history(),
             history_file_path: Self::default_history_file_path(),
             synchronize_selection_with_clipboard:
@@ -125,6 +129,9 @@ impl Config {
     pub const fn default_synchronize_selection_with_clipboard() -> bool { true }
 
     #[inline]
+    pub const fn default_primary_threshold_ms() -> i64 { 0 }
+
+    #[inline]
     pub const fn default_max_history() -> usize { 50 }
 
     #[inline]
@@ -186,6 +193,7 @@ impl From<Config> for clipcat_server::Config {
     fn from(
         Config {
             grpc,
+            primary_threshold_ms,
             max_history,
             synchronize_selection_with_clipboard,
             history_file_path,
@@ -220,6 +228,7 @@ impl From<Config> for clipcat_server::Config {
             grpc_listen_address,
             grpc_local_socket,
             grpc_access_token,
+            primary_threshold_ms,
             max_history,
             synchronize_selection_with_clipboard,
             history_file_path,

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -10,6 +10,8 @@ pub struct Config {
 
     pub grpc_access_token: Option<String>,
 
+    pub primary_threshold_ms: i64,
+
     pub max_history: usize,
 
     pub synchronize_selection_with_clipboard: bool,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -56,6 +56,7 @@ pub async fn serve_with_shutdown(
         grpc_listen_address,
         grpc_local_socket,
         grpc_access_token,
+        primary_threshold_ms,
         max_history,
         history_file_path,
         synchronize_selection_with_clipboard,
@@ -115,6 +116,7 @@ pub async fn serve_with_shutdown(
         tracing::info!("Initialize ClipboardManager with capacity {max_history}");
         let mut clipboard_manager = ClipboardManager::with_capacity(
             clipboard_backend.clone(),
+            primary_threshold_ms,
             max_history,
             desktop_notification.clone(),
         );


### PR DESCRIPTION
The primary_threshold_ms variable defines the time interval, in milliseconds, that controls how often the program updates its stored value of the Linux primary selection. In the Linux environment, the primary selection is a mechanism that automatically updates to reflect the current highlighted text or object, typically updating with every mouse movement.