### PR TITLE
fix #661: Add "process" crate feature for tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tokio = { version = "1", features = [
   "macros",
   "rt-multi-thread",
   "sync",
+  "process",
 ] }
 tokio-stream = { version = "0.1", features = ["net"] }
 


### PR DESCRIPTION
Well somebody had to do it :skull: 

### Changes Made
- Updated `Cargo.toml` to include the `process` feature for the `tokio` crate.

### Related Issues
Fixes #661