### PR TITLE
chore(nix): fix the `version` attribute for `.#container`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
             inherit name rustPlatform;
           };
           container = pkgs.callPackage ./devshell/container.nix {
-            inherit (cargoToml) version;
+            inherit (cargoToml.workspace.package) version;
             inherit name clipcat;
           };
         };


### PR DESCRIPTION
 - Solve #664
