### PR TITLE
fix(clipcatd): tracing while loading config

### DIFF
--- a/clipcatd/src/command.rs
+++ b/clipcatd/src/command.rs
@@ -145,8 +145,6 @@ impl Cli {
 
 #[allow(clippy::cognitive_complexity)]
 fn run_clipcatd(config: Config, replace: bool) -> Result<(), Error> {
-    config.log.registry();
-
     let pid_file = PidFile::from(config.pid_file.clone());
     if pid_file.exists() {
         let pid = pid_file.try_load()?;

--- a/clipcatd/src/config/mod.rs
+++ b/clipcatd/src/config/mod.rs
@@ -164,6 +164,7 @@ impl Config {
             Some(Err(err)) => return Err(err),
             None => None,
         };
+        config.log.registry();
 
         config.max_history =
             if config.max_history == 0 { Self::default_max_history() } else { config.max_history };


### PR DESCRIPTION
Currently `tracing::warn!()` is used in `Cli::load_config()`, which is before tracing is initialized, leading to the warnings not getting logged at all. Initialize tracing as early as possible to prevent such behavior.
