### PR TITLE
feat(clipcatd): filter sensitive content on wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ enable_clipboard = true
 # Enable watching the X11/Wayland primary selection.
 enable_primary = true
 
-# Ignore clips that match any of the X11 `TARGETS`.
-sensitive_x11_atoms = ["x-kde-passwordManagerHint"]
+# Ignore clips that match any of the MIME types.
+sensitive_mime_types = ["x-kde-passwordManagerHint"]
 
 # Ignore text clips that match any of the provided regular expressions.
 # The regular expression engine is powered by https://github.com/rust-lang/regex.

--- a/clipcatd/src/config/mod.rs
+++ b/clipcatd/src/config/mod.rs
@@ -185,6 +185,18 @@ impl Config {
 
         config.history_file_path = resolve_path(&config.history_file_path)?;
 
+        if let Some(x11_atoms) = config.watcher.sensitive_x11_atoms {
+            tracing::warn!(
+                "Found deprecated config key sensitive_x11_atoms, use sensitive_mime_types instead"
+            );
+            if config.watcher.sensitive_mime_types == WatcherConfig::default_sensitive_mime_types()
+            {
+                tracing::info!("Overwriting sensitive_mime_types with sensitive_x11_atoms");
+                config.watcher.sensitive_mime_types = x11_atoms;
+            }
+            config.watcher.sensitive_x11_atoms = None;
+        }
+
         Ok(config)
     }
 }

--- a/clipcatd/src/config/watcher.rs
+++ b/clipcatd/src/config/watcher.rs
@@ -15,8 +15,10 @@ pub struct WatcherConfig {
     #[serde(default = "WatcherConfig::default_enable_secondary")]
     pub enable_secondary: bool,
 
-    #[serde(default = "WatcherConfig::default_sensitive_x11_atoms")]
-    pub sensitive_x11_atoms: HashSet<String>,
+    #[serde(default = "WatcherConfig::default_sensitive_mime_types")]
+    pub sensitive_mime_types: HashSet<String>,
+
+    pub sensitive_x11_atoms: Option<HashSet<String>>,
 
     #[serde(default = "WatcherConfig::default_filter_text_min_length")]
     pub filter_text_min_length: usize,
@@ -45,7 +47,8 @@ impl Default for WatcherConfig {
             filter_text_max_length: Self::default_filter_text_max_length(),
             denied_text_regex_patterns: HashSet::new(),
             filter_image_max_size: Self::default_filter_image_max_size(),
-            sensitive_x11_atoms: Self::default_sensitive_x11_atoms(),
+            sensitive_mime_types: Self::default_sensitive_mime_types(),
+            sensitive_x11_atoms: None,
         }
     }
 }
@@ -61,7 +64,8 @@ impl From<WatcherConfig> for clipcat_server::ClipboardWatcherOptions {
             filter_text_max_length,
             denied_text_regex_patterns,
             filter_image_max_size,
-            sensitive_x11_atoms,
+            sensitive_mime_types,
+            ..
         }: WatcherConfig,
     ) -> Self {
         Self {
@@ -73,7 +77,7 @@ impl From<WatcherConfig> for clipcat_server::ClipboardWatcherOptions {
             filter_text_max_length,
             filter_image_max_size,
             denied_text_regex_patterns,
-            sensitive_x11_atoms,
+            sensitive_mime_types,
         }
     }
 }
@@ -90,7 +94,7 @@ impl WatcherConfig {
 
     pub const fn default_enable_secondary() -> bool { false }
 
-    pub fn default_sensitive_x11_atoms() -> HashSet<String> {
+    pub fn default_sensitive_mime_types() -> HashSet<String> {
         HashSet::from(["x-kde-passwordManagerHint".to_string()])
     }
 }

--- a/crates/base/src/filter.rs
+++ b/crates/base/src/filter.rs
@@ -5,7 +5,7 @@ use crate::ClipboardContent;
 #[derive(Clone, Debug)]
 pub struct Filter {
     regex_set: regex::RegexSet,
-    sensitive_atoms: HashSet<String>,
+    sensitive_mime_types: HashSet<String>,
     deny_image: bool,
     filter_text_min_length: usize,
     filter_text_max_length: usize,
@@ -18,7 +18,7 @@ impl Filter {
         Self {
             regex_set: regex::RegexSet::default(),
 
-            sensitive_atoms: HashSet::new(),
+            sensitive_mime_types: HashSet::new(),
 
             deny_image: false,
 
@@ -36,7 +36,7 @@ impl Filter {
     where
         I: IntoIterator<Item = String>,
     {
-        self.sensitive_atoms.extend(sensitive_atoms);
+        self.sensitive_mime_types.extend(sensitive_atoms);
     }
 
     pub fn set_regex_patterns(&mut self, regex_patterns: regex::RegexSet) {
@@ -67,11 +67,11 @@ impl Filter {
 
     #[inline]
     #[must_use]
-    pub fn filter_sensitive_atoms<'a, I>(&self, mut atoms: I) -> bool
+    pub fn filter_sensitive_mime_type<'a, I>(&self, mut mime_types: I) -> bool
     where
         I: Iterator<Item = &'a String>,
     {
-        atoms.any(|atom| self.sensitive_atoms.contains(atom))
+        mime_types.any(|atom| self.sensitive_mime_types.contains(atom))
     }
 
     #[inline]
@@ -117,7 +117,7 @@ impl Default for Filter {
         Self {
             regex_set: regex::RegexSet::default(),
 
-            sensitive_atoms: HashSet::from(["x-kde-passwordManagerHint".to_string()]),
+            sensitive_mime_types: HashSet::from(["x-kde-passwordManagerHint".to_string()]),
 
             deny_image: false,
 

--- a/crates/clipboard/src/default.rs
+++ b/crates/clipboard/src/default.rs
@@ -103,7 +103,7 @@ impl Clipboard {
                 tracing::info!(
                     "Build Wayland listener ({clipboard_kind}) with display `{display_name}`"
                 );
-                Arc::new(WaylandListener::new(clipboard_kind)?)
+                Arc::new(WaylandListener::new(clipboard_kind, clip_filter)?)
             } else {
                 match std::env::var("DISPLAY") {
                     Ok(display_name) => {

--- a/crates/clipboard/src/listener/x11/mod.rs
+++ b/crates/clipboard/src/listener/x11/mod.rs
@@ -123,7 +123,7 @@ fn build_thread(
                                 match context.get_available_formats() {
                                     Ok(mut formats) => {
                                         // filter sensitive content
-                                        if clip_filter.filter_sensitive_atoms(formats.iter()) {
+                                        if clip_filter.filter_sensitive_mime_type(formats.iter()) {
                                             tracing::info!("Sensitive content detected, ignore it");
                                             continue;
                                         }

--- a/crates/server/src/watcher/options.rs
+++ b/crates/server/src/watcher/options.rs
@@ -23,7 +23,7 @@ pub struct Options {
 
     pub denied_text_regex_patterns: HashSet<String>,
 
-    pub sensitive_x11_atoms: HashSet<String>,
+    pub sensitive_mime_types: HashSet<String>,
 }
 
 impl Options {
@@ -35,7 +35,7 @@ impl Options {
         filter.set_image_max_size(self.filter_image_max_size);
         filter.deny_image(!self.capture_image);
         filter.set_regex_patterns(regex::RegexSet::new(&self.denied_text_regex_patterns)?);
-        filter.add_sensitive_atoms(self.sensitive_x11_atoms.clone());
+        filter.add_sensitive_atoms(self.sensitive_mime_types.clone());
         Ok(filter)
     }
 
@@ -67,7 +67,7 @@ impl Default for Options {
             // 5 MiB
             filter_image_max_size: 5 * (1 << 20),
             denied_text_regex_patterns: HashSet::new(),
-            sensitive_x11_atoms: HashSet::new(),
+            sensitive_mime_types: HashSet::new(),
         }
     }
 }


### PR DESCRIPTION
Filter sensitive content on wayland the same way as on X11.
It would make sense to me to rename the `sensitive_x11_atoms` config value to something like `sensitive_mime_types`, because this is not exclusive to X11 anymore. I renamed the config value and added an according check and warning when `sensitive_x11_atoms` is still set and overwrite `sensitive_mime_types` with its content so we don't have to introduce a breaking change. I did so in a separate commit to make it easy to revert this particular change in case you'd like to go in a different direction. Just let me know.
The warning currently requires the fix in #713 to work properly.
