### PR TITLE
fix(crates/server): remove unnecessary parentheses around closure body

### DIFF
--- a/crates/server/src/snippets/mod.rs
+++ b/crates/server/src/snippets/mod.rs
@@ -39,7 +39,7 @@ async fn load(config: &config::SnippetConfig) -> HashMap<ClipEntry, Option<PathB
                 clipcat_base::utils::fs::read_dir_recursively_async(&path)
                     .await
                     .into_iter()
-                    .map(|file| (async move { (tokio::fs::read(&file).await.ok(), file) })),
+                    .map(|file| async move { (tokio::fs::read(&file).await.ok(), file) }),
             )
             .await
             .into_iter()


### PR DESCRIPTION
This is a lint that prevents the project from compiling with rustc 1.91.0 due to `unused_parens` being set to `deny`.
