### PR TITLE
Support deletion in clipcat-menu with rofi

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,9 @@ menu_length = 30
 # Prompt for the menu.
 menu_prompt = "Clipcat"
 # Extra arguments to pass to `rofi`.
+# Rofi supports deleting entries using kb-custom-1 (default: Alt+1).
+# To rebind to Shift+Delete:
+# extra_arguments = ["-kb-custom-1", "shift+Delete", "-kb-delete-entry", ""]
 extra_arguments = ["-mesg", "Please select a clip"]
 
 # Options for "dmenu".

--- a/clipcat-menu/src/cli/mod.rs
+++ b/clipcat-menu/src/cli/mod.rs
@@ -12,7 +12,7 @@ use tokio::runtime::Runtime;
 use crate::{
     config::Config,
     error::{self, Error},
-    finder::{FinderRunner, FinderType},
+    finder::{FinderRunner, FinderType, MultiSelectionResult, SingleSelectionResult},
     shadow,
 };
 
@@ -187,34 +187,49 @@ impl Cli {
                 }
                 None => insert_clip(&clips, &finder, &client, &[ClipboardKind::Clipboard]).await?,
                 Some(Commands::Remove) => {
-                    let selections = finder.multiple_select(&clips).await?;
-                    let ids: Vec<_> = selections.into_iter().map(|(_, clip)| clip.id).collect();
-                    let removed_ids = client.batch_remove(&ids).await?;
-                    for id in removed_ids {
-                        tracing::info!("Removing clip (id: {id:016x})");
+                    let result = finder.multiple_select(&clips).await?;
+                    match result {
+                        MultiSelectionResult::Select(selections)
+                        | MultiSelectionResult::Delete(selections) => {
+                            let ids: Vec<_> = selections.iter().map(|(_, clip)| clip.id).collect();
+                            let removed_ids = client.batch_remove(&ids).await?;
+                            for id in removed_ids {
+                                tracing::info!("Removing clip (id: {id:016x})");
+                            }
+                        }
+                        MultiSelectionResult::Cancel => {
+                            tracing::info!("Nothing is selected");
+                        }
                     }
                 }
                 Some(Commands::Edit { editor }) => {
-                    let selection = finder.single_select(&clips).await?;
-                    if let Some((_index, metadata)) = selection {
-                        let clip = client.get(metadata.id).await?;
-                        if clip.is_utf8_string() {
-                            let editor = ExternalEditor::new(editor);
-                            let new_data = editor
-                                .execute(&clip.as_utf8_string())
-                                .await
-                                .context(error::CallEditorSnafu)?;
-                            let (ok, new_id) =
-                                client.update(clip.id(), new_data.as_bytes(), clip.mime()).await?;
-                            if ok {
-                                tracing::info!("Editing clip (id: {:016x})", new_id);
+                    let result = finder.single_select(&clips).await?;
+                    match result {
+                        SingleSelectionResult::Select(_, metadata) => {
+                            let clip = client.get(metadata.id).await?;
+                            if clip.is_utf8_string() {
+                                let editor = ExternalEditor::new(editor);
+                                let new_data = editor
+                                    .execute(&clip.as_utf8_string())
+                                    .await
+                                    .context(error::CallEditorSnafu)?;
+                                let (ok, new_id) = client
+                                    .update(clip.id(), new_data.as_bytes(), clip.mime())
+                                    .await?;
+                                if ok {
+                                    tracing::info!("Editing clip (id: {:016x})", new_id);
+                                }
+                                let _ok = client.mark(new_id, ClipboardKind::Clipboard).await?;
+                                drop(client);
                             }
-                            let _ok = client.mark(new_id, ClipboardKind::Clipboard).await?;
-                            drop(client);
                         }
-                    } else {
-                        tracing::info!("Nothing is selected");
-                        return Ok(());
+                        SingleSelectionResult::Delete(index, clip) => {
+                            tracing::info!("Deleting clip (index: {index}, id: {:016x})", clip.id);
+                            let _removed_ids = client.batch_remove(&[clip.id]).await?;
+                        }
+                        SingleSelectionResult::Cancel => {
+                            tracing::info!("Nothing is selected");
+                        }
                     }
                 }
                 _ => unreachable!(),
@@ -233,14 +248,21 @@ async fn insert_clip(
     client: &Client,
     clipboard_kinds: &[ClipboardKind],
 ) -> Result<(), Error> {
-    let selection = finder.single_select(clips).await?;
-    if let Some((index, clip)) = selection {
-        tracing::info!("Inserting clip (index: {index}, id: {:016x})", clip.id);
-        for &clipboard_kind in clipboard_kinds {
-            let _ok = client.mark(clip.id, clipboard_kind).await?;
+    let result = finder.single_select(clips).await?;
+    match result {
+        SingleSelectionResult::Select(index, clip) => {
+            tracing::info!("Inserting clip (index: {index}, id: {:016x})", clip.id);
+            for &clipboard_kind in clipboard_kinds {
+                let _ok = client.mark(clip.id, clipboard_kind).await?;
+            }
         }
-    } else {
-        tracing::info!("Nothing is selected");
+        SingleSelectionResult::Delete(index, clip) => {
+            tracing::info!("Deleting clip (index: {index}, id: {:016x})", clip.id);
+            let _removed_ids = client.batch_remove(&[clip.id]).await?;
+        }
+        SingleSelectionResult::Cancel => {
+            tracing::info!("Nothing is selected");
+        }
     }
 
     Ok(())

--- a/clipcat-menu/src/finder/external/rofi.rs
+++ b/clipcat-menu/src/finder/external/rofi.rs
@@ -3,7 +3,8 @@ use clipcat_base::ClipEntryMetadata;
 use crate::{
     config,
     finder::{
-        FinderStream, SelectionMode, external::ExternalProgram, finder_stream::ENTRY_SEPARATOR,
+        FinderResult, FinderStream, SelectionMode, external::ExternalProgram,
+        finder_stream::ENTRY_SEPARATOR,
     },
 };
 
@@ -61,6 +62,15 @@ impl FinderStream for Rofi {
             .collect()
     }
 
+    fn parse_result(&self, data: &[u8], exit_code: Option<i32>) -> FinderResult {
+        let indices = self.parse_output(data);
+        match exit_code {
+            Some(10) if !indices.is_empty() => FinderResult::Delete(indices),
+            _ if indices.is_empty() => FinderResult::Cancel,
+            _ => FinderResult::Select(indices),
+        }
+    }
+
     fn set_line_length(&mut self, line_length: usize) { self.line_length = line_length }
 
     fn set_menu_length(&mut self, menu_length: usize) { self.menu_length = menu_length; }
@@ -74,7 +84,7 @@ impl FinderStream for Rofi {
 mod tests {
     use crate::{
         config,
-        finder::{Rofi, SelectionMode, external::ExternalProgram},
+        finder::{FinderResult, FinderStream, Rofi, SelectionMode, external::ExternalProgram},
     };
 
     #[test]
@@ -121,5 +131,22 @@ mod tests {
                 "Please select a clip".to_owned()
             ]
         );
+    }
+
+    #[test]
+    fn test_parse_result() {
+        let rofi = Rofi::from(config::Rofi::default());
+
+        assert_eq!(rofi.parse_result(b"0", Some(0)), FinderResult::Select(vec![0]));
+        assert_eq!(rofi.parse_result(b"5", None), FinderResult::Select(vec![5]));
+        assert_eq!(rofi.parse_result(b"1\n2\n3", Some(0)), FinderResult::Select(vec![1, 2, 3]));
+
+        assert_eq!(rofi.parse_result(b"", Some(0)), FinderResult::Cancel);
+        assert_eq!(rofi.parse_result(b"", Some(1)), FinderResult::Cancel);
+
+        assert_eq!(rofi.parse_result(b"3", Some(10)), FinderResult::Delete(vec![3]));
+        assert_eq!(rofi.parse_result(b"0", Some(10)), FinderResult::Delete(vec![0]));
+        assert_eq!(rofi.parse_result(b"", Some(10)), FinderResult::Cancel);
+        assert_eq!(rofi.parse_result(b"5\n2\n3", Some(10)), FinderResult::Delete(vec![5, 2, 3]));
     }
 }

--- a/clipcat-menu/src/finder/finder_stream.rs
+++ b/clipcat-menu/src/finder/finder_stream.rs
@@ -1,5 +1,7 @@
 use clipcat_base::ClipEntryMetadata;
 
+use crate::finder::FinderResult;
+
 pub const ENTRY_SEPARATOR: &str = "\n";
 pub const INDEX_SEPARATOR: char = ':';
 
@@ -25,6 +27,11 @@ pub trait FinderStream: Send + Sync {
                     .ok()
             })
             .collect()
+    }
+
+    fn parse_result(&self, data: &[u8], _exit_code: Option<i32>) -> FinderResult {
+        let indices = self.parse_output(data);
+        if indices.is_empty() { FinderResult::Cancel } else { FinderResult::Select(indices) }
     }
 
     fn set_extra_arguments(&mut self, _arguments: &[String]) {}

--- a/clipcat-menu/src/finder/mod.rs
+++ b/clipcat-menu/src/finder/mod.rs
@@ -23,6 +23,27 @@ pub enum SelectionMode {
     Multiple,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FinderResult {
+    Select(Vec<usize>),
+    Delete(Vec<usize>),
+    Cancel,
+}
+
+#[derive(Clone, Debug)]
+pub enum SingleSelectionResult {
+    Select(usize, ClipEntryMetadata),
+    Delete(usize, ClipEntryMetadata),
+    Cancel,
+}
+
+#[derive(Clone, Debug)]
+pub enum MultiSelectionResult {
+    Select(Vec<(usize, ClipEntryMetadata)>),
+    Delete(Vec<(usize, ClipEntryMetadata)>),
+    Cancel,
+}
+
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum FinderType {
     #[default]
@@ -138,33 +159,50 @@ impl FinderRunner {
     pub async fn single_select(
         &self,
         clips: &[ClipEntryMetadata],
-    ) -> Result<Option<(usize, ClipEntryMetadata)>, FinderError> {
-        let selected_indices = self.select(clips, SelectionMode::Single).await?;
-        if let Some(&selected_index) = selected_indices.first() {
-            let selected_data = &clips[selected_index];
-            Ok(Some((selected_index, selected_data.clone())))
-        } else {
-            Ok(None)
-        }
+    ) -> Result<SingleSelectionResult, FinderError> {
+        let result = self.select(clips, SelectionMode::Single).await?;
+        Ok(match result {
+            FinderResult::Select(indices) => match indices.first() {
+                Some(&index) => SingleSelectionResult::Select(index, clips[index].clone()),
+                None => SingleSelectionResult::Cancel,
+            },
+            FinderResult::Delete(indices) => match indices.first() {
+                Some(&index) => SingleSelectionResult::Delete(index, clips[index].clone()),
+                None => SingleSelectionResult::Cancel,
+            },
+            FinderResult::Cancel => SingleSelectionResult::Cancel,
+        })
     }
 
     pub async fn multiple_select(
         &self,
         clips: &[ClipEntryMetadata],
-    ) -> Result<Vec<(usize, ClipEntryMetadata)>, FinderError> {
-        let selected_indices = self.select(clips, SelectionMode::Multiple).await?;
-        Ok(selected_indices.into_iter().map(|index| (index, clips[index].clone())).collect())
+    ) -> Result<MultiSelectionResult, FinderError> {
+        let result = self.select(clips, SelectionMode::Multiple).await?;
+        let to_selections = |indices: Vec<usize>| {
+            indices.into_iter().map(|index| (index, clips[index].clone())).collect()
+        };
+        Ok(match result {
+            FinderResult::Select(indices) => MultiSelectionResult::Select(to_selections(indices)),
+            FinderResult::Delete(indices) => MultiSelectionResult::Delete(to_selections(indices)),
+            FinderResult::Cancel => MultiSelectionResult::Cancel,
+        })
     }
 
     pub async fn select(
         &self,
         clips: &[ClipEntryMetadata],
         selection_mode: SelectionMode,
-    ) -> Result<Vec<usize>, FinderError> {
+    ) -> Result<FinderResult, FinderError> {
         if self.external.is_some() {
             self.select_externally(clips, selection_mode).await
         } else {
-            BuiltinFinder::new().select(clips, selection_mode).await
+            let indices = BuiltinFinder::new().select(clips, selection_mode).await?;
+            if indices.is_empty() {
+                Ok(FinderResult::Cancel)
+            } else {
+                Ok(FinderResult::Select(indices))
+            }
         }
     }
 
@@ -172,7 +210,7 @@ impl FinderRunner {
         &self,
         clips: &[ClipEntryMetadata],
         selection_mode: SelectionMode,
-    ) -> Result<Vec<usize>, FinderError> {
+    ) -> Result<FinderResult, FinderError> {
         if let Some(external) = &self.external {
             let input_data = external.generate_input(clips);
             let mut child = external
@@ -184,13 +222,11 @@ impl FinderRunner {
             }
 
             let output = child.wait_with_output().await.context(error::ReadStdoutSnafu)?;
-            if output.stdout.is_empty() {
-                return Ok(Vec::new());
-            }
+            let exit_code = output.status.code();
 
-            Ok(external.parse_output(output.stdout.as_slice()))
+            Ok(external.parse_result(output.stdout.as_slice(), exit_code))
         } else {
-            Ok(Vec::new())
+            Ok(FinderResult::Cancel)
         }
     }
 


### PR DESCRIPTION
rofi supports custom keybindings and signals their usage in exit code (Alt+N by default with 9+N exit code).

I know you have `clipcat-menu remove` but oftentimes I open the normal `clipcat-menu` menu to paste and see something that should not be persisted like a password and want to get it out. I could also imagine same happening when using `clipcat-menu edit`, this way `clipcat-menu edit` could be used to both remove and edit which I consider an extra win. User can customize keybinding using `extra_arguments`.

I [asked](https://github.com/davatorium/rofi/discussions/2086#discussioncomment-15688670) rofi if they want to signal Shift+Delete (which they support in some builtin modes and in script mode but not in dmenu mode), if they agree this integration could be improved later.