### PR TITLE
Do not skip thread sleep when sensitive content is detected for wayland

### DIFF
--- a/crates/clipboard/src/listener/wayland/mod.rs
+++ b/crates/clipboard/src/listener/wayland/mod.rs
@@ -84,16 +84,21 @@ fn build_thread(
     thread::Builder::new()
         .name(format!("{clipboard_type:?}-listener"))
         .spawn(move || {
+            let mut last_is_sensitive = false;
+            let mut current_is_sensitive;
             while is_running.load(Ordering::Relaxed) {
                 tracing::trace!("Wait for readiness events");
 
-                match wl_clipboard_get_mime_types(clipboard_type, Seat::Unspecified) {
-                    Ok(mime_types) => {
-                        if clip_filter.filter_sensitive_mime_type(mime_types.iter()) {
-                            tracing::info!("Sensitive content detected, ignore it");
-                            continue;
-                        }
+                current_is_sensitive = false;
 
+                match wl_clipboard_get_mime_types(clipboard_type, Seat::Unspecified) {
+                    Ok(mime_types) if clip_filter.filter_sensitive_mime_type(mime_types.iter()) => {
+                        if !last_is_sensitive {
+                            tracing::info!("Sensitive content detected, ignore it");
+                        };
+                        current_is_sensitive = true;
+                    }
+                    Ok(mime_types) => {
                         let mut mime_types = mime_types.into_iter().collect::<Vec<_>>();
                         mime_types.sort_unstable_by_key(|format| {
                             if format.starts_with("image") {
@@ -126,6 +131,8 @@ fn build_thread(
                         "Error occurs while listening to clipboard of Wayland, error: {err}"
                     ),
                 }
+
+                last_is_sensitive = current_is_sensitive;
 
                 // Sleep for a while there is no content or error occurred
                 thread::sleep(POLLING_INTERVAL);


### PR DESCRIPTION
When sensitive content was detected, the thread sleep instruction was skipped because of a continue statement. This was creating spam log and heavy CPU usage. 

It has been fixed by removing the continue statement and only printing the log message once (per selection).

closes #944 

---

Let me know if you want me to change something. I can remove the state check, but it would print log every 500ms.