### PR TITLE
fix(clipcat-menu): fuzzel always fails to select clipboard entry

### DIFF
--- a/clipcat-menu/src/finder/external/fuzzel.rs
+++ b/clipcat-menu/src/finder/external/fuzzel.rs
@@ -53,13 +53,14 @@ impl FinderStream for Fuzzel {
     fn generate_input(&self, clips: &[ClipEntryMetadata]) -> String {
         clips
             .iter()
-            .map(|clip| {
+            .enumerate()
+            .map(|(i, clip)| {
                 let prefix = if self.show_source_prefix {
                     format!("{} ", clip.kind.prefix())
                 } else {
                     String::new()
                 };
-                format!("{prefix}{}", clip.preview)
+                format!("{i}{INDEX_SEPARATOR} {prefix}{}", clip.preview)
             })
             .collect::<Vec<_>>()
             .join(ENTRY_SEPARATOR)


### PR DESCRIPTION
This regression was introduced in fdde615ca05365adc40c67e318f0c2944157970a.
