### PR TITLE
ci(container): skip image push on fork pull requests

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: docker/bake-action@v7
         with:
           pull: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           set: |
             clipcat.args.SCCACHE_GHA_ENABLED=on
             clipcat.args.ACTIONS_CACHE_URL=${{ env.ACTIONS_CACHE_URL }}


### PR DESCRIPTION
Fork pull requests get a read-only `GITHUB_TOKEN` for the upstream organization's GHCR namespace, so the unconditional `push: true` on the bake step always fails with `denied: installation not allowed to Write organization package`, turning the Container check red on every PR opened from a fork.

Make the push conditional: still publish on push events and on PRs from branches in the same repository (preserving the existing `pr-N` tag behavior for upstream PRs), but only build (no push) when the PR head lives in a different repository.