### PR TITLE
fix(clipcatctl): fix output ordering of list cmd

### DIFF
--- a/clipcatctl/src/cli.rs
+++ b/clipcatctl/src/cli.rs
@@ -473,6 +473,7 @@ async fn print_list(
     show_source_prefix: bool,
 ) -> Result<(), Error> {
     let metadata_list = client.list(preview_length).await?;
+    let mut stdout = tokio::io::stdout();
     for metadata in metadata_list {
         let ClipEntryMetadata { id, preview, kind, .. } = metadata;
         let prefix = if show_source_prefix { format!("{} ", kind.prefix()) } else { String::new() };
@@ -481,7 +482,7 @@ async fn print_list(
         } else {
             format!("{id:016x}: {prefix}{preview}\n")
         };
-        tokio::io::stdout().write_all(output.as_bytes()).await.context(error::WriteStdoutSnafu)?;
+        stdout.write_all(output.as_bytes()).await.context(error::WriteStdoutSnafu)?;
     }
     Ok(())
 }


### PR DESCRIPTION
Hi,

this is a fix for #1053 . Output is not stable becuase fresh instance of `tokio::io::stdout` is created inside `for` loop for ever entry. Each `stdout` has its dedicated worker creating a race condition. Creating single instance outside the loop solves the problem. See commentary in [tokio doc](https://docs.rs/tokio/latest/tokio/io/struct.Stdout.html). I have tested it locally and the problem is gone.

Let me know if I need to update anything :+1: 